### PR TITLE
Add loot announce, auto resets when changing raid, and countdown

### DIFF
--- a/LootBlare.toc
+++ b/LootBlare.toc
@@ -13,6 +13,7 @@ LootBlare\sr_handler.lua
 LootBlare\plus_one_handler.lua
 LootBlare\alts_handler.lua
 LootBlare\change_zone_handler.lua
+LootBlare\loot_annaunce_handler.lua
 LootBlare\minimap_button.lua
 LootBlare\ui.lua
 LootBlare\chat_handler.lua

--- a/LootBlare/LootBlare.lua
+++ b/LootBlare/LootBlare.lua
@@ -7,6 +7,7 @@ item_roll_frame:RegisterEvent('CHAT_MSG_RAID_LEADER')
 item_roll_frame:RegisterEvent('CHAT_MSG_ADDON')
 item_roll_frame:RegisterEvent('CURRENT_SPELL_CAST_CHANGED')
 item_roll_frame:RegisterEvent('ZONE_CHANGED_NEW_AREA')
+item_roll_frame:RegisterEvent('LOOT_OPENED')
 item_roll_frame:SetScript('OnEvent',
                           function() handle_chat_message(event, arg1, arg2) end)
 

--- a/LootBlare/change_zone_handler.lua
+++ b/LootBlare/change_zone_handler.lua
@@ -7,7 +7,7 @@ TWOW_RAID_NAMES = {
   ["Blackwing Lair"] = true,
   ["Ahn'Qiraj"] = true,
   ["Naxxramas"] = true,
-  ["Tower of Kharazhan"] = true
+  ["Tower of Karazhan"] = true
 }
 
 function reset_plus_one_when_entering_raid()

--- a/LootBlare/change_zone_handler.lua
+++ b/LootBlare/change_zone_handler.lua
@@ -28,6 +28,7 @@ function reset_plus_one_when_entering_raid()
 
   if is_a_new_raid then
     PlusOneList = {}
+    LastRaidData.AlreadyLooted = {}
     LastRaidData.RaidName = current_zone
     LastRaidData.RaidTime = current_time
     lb_print('Plus one list cleared for entering a new raid: ' .. current_zone)

--- a/LootBlare/change_zone_handler.lua
+++ b/LootBlare/change_zone_handler.lua
@@ -29,8 +29,6 @@ function reset_plus_one_when_entering_raid()
   if is_a_new_raid then
     PlusOneList = {}
     LastRaidData.AlreadyLooted = {}
-    LastRaidData.RaidName = current_zone
-    LastRaidData.RaidTime = current_time
     lb_print('Plus one list cleared for entering a new raid: ' .. current_zone)
   end
 end

--- a/LootBlare/change_zone_handler.lua
+++ b/LootBlare/change_zone_handler.lua
@@ -29,6 +29,8 @@ function reset_plus_one_when_entering_raid()
   if is_a_new_raid then
     PlusOneList = {}
     LastRaidData.AlreadyLooted = {}
+    LastRaidData.RaidName = current_zone
+    LastRaidData.RaidTime = current_time
     lb_print('Plus one list cleared for entering a new raid: ' .. current_zone)
   end
 end

--- a/LootBlare/chat_handler.lua
+++ b/LootBlare/chat_handler.lua
@@ -139,7 +139,9 @@ function handle_chat_message(event, message, sender)
     if AltList == nil then AltList = {} end
     if SRList == nil then SRList = {} end
     if PlusOneList == nil then PlusOneList = {} end
-    if LastRaidData == nil then LastRaidData = {RaidName = '', RaidTime = 0} end
+    if LastRaidData == nil then
+      LastRaidData = {RaidName = '', RaidTime = 0, AlreadyLooted = {}}
+    end
 
     if is_master_looter(UnitName('player')) then
       master_looter = UnitName('player')

--- a/LootBlare/chat_handler.lua
+++ b/LootBlare/chat_handler.lua
@@ -128,8 +128,12 @@ function handle_chat_message(event, message, sender)
         ResetPOAfterImportingSR = true,
         CustomFontSize = config.CLICKABLE_TEXT_FONT_SIZE,
         PrioMainOverAlts = true,
+        LootAnnounceActive = true,
         LootAnnounceMinQuality = 4 -- Epic
       }
+    end
+    if Settings.LootAnnounceActive == nil then
+      Settings.LootAnnounceActive = true
     end
 
     if Settings.LootAnnounceMinQuality == nil then

--- a/LootBlare/chat_handler.lua
+++ b/LootBlare/chat_handler.lua
@@ -127,8 +127,13 @@ function handle_chat_message(event, message, sender)
         HideWhenUsingSpell = false,
         ResetPOAfterImportingSR = true,
         CustomFontSize = config.CLICKABLE_TEXT_FONT_SIZE,
-        PrioMainOverAlts = true
+        PrioMainOverAlts = true,
+        LootAnnounceMinQuality = 4 -- Epic
       }
+    end
+
+    if Settings.LootAnnounceMinQuality == nil then
+      Settings.LootAnnounceMinQuality = 4 -- Epic
     end
 
     if AltList == nil then AltList = {} end

--- a/LootBlare/chat_handler.lua
+++ b/LootBlare/chat_handler.lua
@@ -144,6 +144,8 @@ function handle_chat_message(event, message, sender)
     end
   elseif event == 'ZONE_CHANGED_NEW_AREA' then
     reset_plus_one_when_entering_raid()
+  elseif event == 'LOOT_OPENED' then
+    run_if_master_looter(function() loot_announce_handler() end, false)
   end
 end
 

--- a/LootBlare/loot_annaunce_handler.lua
+++ b/LootBlare/loot_annaunce_handler.lua
@@ -3,6 +3,19 @@ local function getGuid()
   return guid
 end
 
+EXCLUDED_ITEMS_TABLE = {
+  ["Sulfuron Ingot"] = true,
+  ["Elementium Ore"] = true,
+  ["Fading Dream Fragment"] = true,
+  ["Wartorn Cloth Scrap"] = true,
+  ["Wartorn Leather Scrap"] = true,
+  ["Wartorn Chain Scrap"] = true,
+  ["Wartorn Plate Scrap"] = true,
+  ["Pristine Lay Crytstal"] = true
+}
+
+IDOL_PREFIX = "Idol"
+
 function loot_announce_handler()
   local unit_guid = getGuid()
   if LastRaidData.AlreadyLooted[unit_guid] then
@@ -14,11 +27,14 @@ function loot_announce_handler()
 
   for lootedindex = 1, GetNumLootItems() do
     local min_quality = tonumber(Settings.LootAnnounceMinQuality)
+    lb_print(tostring(min_quality))
     local item_link = GetLootSlotLink(lootedindex)
     if item_link then
       local item_id = tonumber(string.match(item_link, "item:(%d+):"))
-      local item_quality = select(3, GetItemInfo(item_id))
-      if item_quality and item_quality >= min_quality then
+      local item_name, _, item_quality = GetItemInfo(item_id)
+      if item_quality and item_quality >= min_quality and
+        not EXCLUDED_ITEMS_TABLE[item_name] and
+        not string.find(item_name, IDOL_PREFIX) then
         announcestring = announcestring .. " " .. item_link
       end
     end

--- a/LootBlare/loot_annaunce_handler.lua
+++ b/LootBlare/loot_annaunce_handler.lua
@@ -14,7 +14,6 @@ function loot_announce_handler()
 
   for lootedindex = 1, GetNumLootItems() do
     local min_quality = tonumber(Settings.LootAnnounceMinQuality)
-    lb_print(tostring(min_quality))
     local item_link = GetLootSlotLink(lootedindex)
     if item_link then
       local item_id = tonumber(string.match(item_link, "item:(%d+):"))

--- a/LootBlare/loot_annaunce_handler.lua
+++ b/LootBlare/loot_annaunce_handler.lua
@@ -17,6 +17,10 @@ EXCLUDED_ITEMS_TABLE = {
 IDOL_PREFIX = "Idol"
 
 function loot_announce_handler()
+  if not Settings.LootAnnounceActive then
+    return -- If loot announcements are disabled, do nothing
+  end
+
   local has_superwow = SetAutoloot and true or false
 
   if has_superwow then

--- a/LootBlare/loot_annaunce_handler.lua
+++ b/LootBlare/loot_annaunce_handler.lua
@@ -1,0 +1,32 @@
+already_looted = {}
+
+local function getGuid()
+  local _, guid = UnitExists("target")
+  return guid
+end
+
+function loot_announce_handler()
+  local unit_guid = getGuid()
+  if already_looted[unit_guid] then
+    return -- If this unit has already been looted, do nothing
+  end
+  already_looted[unit_guid] = true -- Mark this unit as looted to avoid duplicate announcements
+
+  local announcestring = "Items inside:"
+
+  for lootedindex = 1, GetNumLootItems() do
+    local MINIMUN_QUALITY_TO_ANNOUNCE = 4 -- 4 is the rarity for epic items
+    local item_link = GetLootSlotLink(lootedindex)
+    if item_link then
+      local item_id = tonumber(string.match(item_link, "item:(%d+):"))
+      local item_quality = select(3, GetItemInfo(item_id))
+      if item_quality and item_quality >= MINIMUN_QUALITY_TO_ANNOUNCE then
+        announcestring = announcestring .. " " .. item_link
+      end
+    end
+  end
+
+  if announcestring ~= "Items inside:" then
+    SendChatMessage(announcestring, "RAID", nil, nil)
+  end
+end

--- a/LootBlare/loot_annaunce_handler.lua
+++ b/LootBlare/loot_annaunce_handler.lua
@@ -15,12 +15,13 @@ function loot_announce_handler()
   local announcestring = "Items inside:"
 
   for lootedindex = 1, GetNumLootItems() do
-    local MINIMUN_QUALITY_TO_ANNOUNCE = 4 -- 4 is the rarity for epic items
+    local min_quality = tonumber(Settings.LootAnnounceMinQuality)
+    lb_print(tostring(min_quality))
     local item_link = GetLootSlotLink(lootedindex)
     if item_link then
       local item_id = tonumber(string.match(item_link, "item:(%d+):"))
       local item_quality = select(3, GetItemInfo(item_id))
-      if item_quality and item_quality >= MINIMUN_QUALITY_TO_ANNOUNCE then
+      if item_quality and item_quality >= min_quality then
         announcestring = announcestring .. " " .. item_link
       end
     end

--- a/LootBlare/loot_annaunce_handler.lua
+++ b/LootBlare/loot_annaunce_handler.lua
@@ -17,17 +17,20 @@ EXCLUDED_ITEMS_TABLE = {
 IDOL_PREFIX = "Idol"
 
 function loot_announce_handler()
-  local unit_guid = getGuid()
-  if LastRaidData.AlreadyLooted[unit_guid] then
-    return -- If this unit has already been looted, do nothing
+  local has_superwow = SetAutoloot and true or false
+
+  if has_superwow then
+    local unit_guid = getGuid()
+    if LastRaidData.AlreadyLooted[unit_guid] then
+      return -- If this unit has already been looted, do nothing
+    end
+    LastRaidData.AlreadyLooted[unit_guid] = true -- Mark this unit as looted to avoid duplicate announcements
   end
-  LastRaidData.AlreadyLooted[unit_guid] = true -- Mark this unit as looted to avoid duplicate announcements
 
   local announcestring = "Items inside:"
 
   for lootedindex = 1, GetNumLootItems() do
     local min_quality = tonumber(Settings.LootAnnounceMinQuality)
-    lb_print(tostring(min_quality))
     local item_link = GetLootSlotLink(lootedindex)
     if item_link then
       local item_id = tonumber(string.match(item_link, "item:(%d+):"))

--- a/LootBlare/loot_annaunce_handler.lua
+++ b/LootBlare/loot_annaunce_handler.lua
@@ -1,5 +1,3 @@
-already_looted = {}
-
 local function getGuid()
   local _, guid = UnitExists("target")
   return guid
@@ -7,10 +5,10 @@ end
 
 function loot_announce_handler()
   local unit_guid = getGuid()
-  if already_looted[unit_guid] then
+  if LastRaidData.AlreadyLooted[unit_guid] then
     return -- If this unit has already been looted, do nothing
   end
-  already_looted[unit_guid] = true -- Mark this unit as looted to avoid duplicate announcements
+  LastRaidData.AlreadyLooted[unit_guid] = true -- Mark this unit as looted to avoid duplicate announcements
 
   local announcestring = "Items inside:"
 

--- a/LootBlare/roll_handler.lua
+++ b/LootBlare/roll_handler.lua
@@ -11,6 +11,9 @@ item_query = 0.5
 times = 5
 master_looter = nil
 RollType = {SR_MS = 102, SR_OS = 101, MS = 100, OS = 99, TM = 50}
+seconds_3 = false
+seconds_2 = false
+seconds_1 = false
 
 function reset_rolls()
   ms_roll_messages = {}
@@ -41,7 +44,7 @@ function sort_rolls()
     local a_plus_one = PlusOneList[a.roller] or 0
     local b_plus_one = PlusOneList[b.roller] or 0
     local prio_mains = Settings.PrioMainOverAlts
-    
+
     if prio_mains and (a_alt and not b_alt) then return false end
     if prio_mains and (not a_alt and b_alt) then return true end
     if a_plus_one == b_plus_one then return a.roll > b.roll end

--- a/LootBlare/sr_handler.lua
+++ b/LootBlare/sr_handler.lua
@@ -122,6 +122,11 @@ function find_soft_reservers_for_item(item_link)
   -- Filter out members not in the raid
   for i = len(current_item_sr), 1, -1 do
     if not is_member_in_raid(current_item_sr[i]["Attendee"]) then
+      -- if ML announce if someone SRed but is not in raid
+      run_if_master_looter(function()
+        SendChatMessage(current_item_sr[i]["Attendee"] ..
+                          ' reservó pero no está en raid!', 'RAID')
+      end, false)
       table.remove(current_item_sr, i)
     end
   end

--- a/LootBlare/sr_handler.lua
+++ b/LootBlare/sr_handler.lua
@@ -122,11 +122,6 @@ function find_soft_reservers_for_item(item_link)
   -- Filter out members not in the raid
   for i = len(current_item_sr), 1, -1 do
     if not is_member_in_raid(current_item_sr[i]["Attendee"]) then
-      -- if ML announce if someone SRed but is not in raid
-      run_if_master_looter(function()
-        SendChatMessage(current_item_sr[i]["Attendee"] ..
-                          ' reservó pero no está en raid!', 'RAID')
-      end, false)
       table.remove(current_item_sr, i)
     end
   end

--- a/LootBlare/ui.lua
+++ b/LootBlare/ui.lua
@@ -587,7 +587,7 @@ end
 function create_settings_frame()
   local frame = CreateFrame('Frame', 'settings_frame', UIParent)
   frame:SetWidth(300)
-  frame:SetHeight(360)
+  frame:SetHeight(390)
   frame:SetPoint('CENTER', UIParent, 'CENTER', 0, 0)
   frame:SetBackdrop({
     bgFile = 'Interface/Tooltips/UI-Tooltip-Background',
@@ -687,12 +687,20 @@ function create_settings_frame()
     'Reset PO after importing SRs');
   reset_po_after_importing_sr_cb.tooltip = 'Reset PO after importing SRs'
 
+  -- loot announce on or off
+  local loot_announce_cb = CreateFrame('CheckButton', 'loot_announce_cb', frame,
+                                       'UICheckButtonTemplate')
+  loot_announce_cb:SetPoint('TOPLEFT', reset_po_after_importing_sr_cb,
+                            'BOTTOMLEFT', 0, 0)
+  getglobal(loot_announce_cb:GetName() .. 'Text'):SetText(
+    'Loot announce on or off');
+  loot_announce_cb.tooltip = 'Loot announce on or off'
+
   -- min quality for items to announce in chat
   local loot_announce_min_quality_edit_box =
     CreateFrame('EditBox', 'loot_announce_min_quality_edit_box', frame,
                 'InputBoxTemplate')
-  loot_announce_min_quality_edit_box:SetPoint('TOPLEFT',
-                                              reset_po_after_importing_sr_cb,
+  loot_announce_min_quality_edit_box:SetPoint('TOPLEFT', loot_announce_cb,
                                               'BOTTOMLEFT', 10, -10)
   loot_announce_min_quality_edit_box:SetWidth(20)
   loot_announce_min_quality_edit_box:SetHeight(15)
@@ -714,11 +722,15 @@ function create_settings_frame()
       reset_po_after_importing_sr_cb:Hide()
       loot_announce_min_quality_edit_box:Hide()
       loot_announce_min_quality_label:Hide()
+      loot_announce_cb:Disable()
+      loot_announce_cb:Hide()
     else
       prio_main_over_alts_cb:Enable()
       reset_po_after_importing_sr_cb:Enable()
       reset_po_after_importing_sr_cb:Show()
       loot_announce_min_quality_edit_box:Show()
+      loot_announce_cb:Enable()
+      loot_announce_cb:Show()
       loot_announce_min_quality_label:Show()
     end
 
@@ -730,6 +742,7 @@ function create_settings_frame()
     frame_duration_edit_box:SetText(Settings.RollDuration)
     reset_po_after_importing_sr_cb:SetChecked(Settings.ResetPOAfterImportingSR)
     prio_main_over_alts_cb:SetChecked(Settings.PrioMainOverAlts)
+    loot_announce_cb:SetChecked(Settings.LootAnnounceActive)
     loot_announce_min_quality_edit_box:SetText(
       Settings.LootAnnounceMinQuality or 4)
   end)
@@ -747,6 +760,7 @@ function create_settings_frame()
       Settings.ResetPOAfterImportingSR =
         reset_po_after_importing_sr_cb:GetChecked() == 1
       Settings.PrioMainOverAlts = prio_main_over_alts_cb:GetChecked() == 1
+      Settings.LootAnnounceActive = loot_announce_cb:GetChecked() == 1
       Settings.LootAnnounceMinQuality =
         loot_announce_min_quality_edit_box:GetText()
       send_ml_settings()

--- a/LootBlare/ui.lua
+++ b/LootBlare/ui.lua
@@ -546,6 +546,9 @@ function create_import_sr_frame()
                                      'UIPanelButtonTemplate')
   reset_plus_one:SetScript('OnClick', function()
     PlusOneList = {}
+    LastRaidData.AlreadyLooted = {}
+    LastRaidData.RaidName = ''
+    LastRaidData.RaidTime = 0
     edit_box:SetText('')
   end)
   reset_plus_one:SetPoint('RIGHT', import_button, 'LEFT', -10, 0)

--- a/LootBlare/ui.lua
+++ b/LootBlare/ui.lua
@@ -402,13 +402,34 @@ function show_frame(frame, duration, item)
     if frame.timerText then
       frame.timerText:SetText(format('%.1f', duration - time_elapsed))
     end
+
+    if time_elapsed >= duration - 3 and time_elapsed < duration - 2 and
+      not seconds_3 then
+      seconds_3 = true
+      run_if_master_looter(function() SendChatMessage('3', 'RAID') end)
+    elseif time_elapsed >= duration - 2 and time_elapsed < duration - 1 and
+      not seconds_2 then
+      seconds_2 = true
+      run_if_master_looter(function() SendChatMessage('2', 'RAID') end)
+    elseif time_elapsed >= duration - 1 and time_elapsed < duration and
+      not seconds_1 then
+      seconds_1 = true
+      run_if_master_looter(function() SendChatMessage('1', 'RAID') end)
+    end
+
     if time_elapsed >= duration then
+      run_if_master_looter(function()
+        SendChatMessage('Roll time ended!', 'RAID')
+      end)
       frame:SetScript('OnUpdate', nil)
       time_elapsed = 0
       item_query = 1.5
       times = 3
       roll_messages = {}
       is_rolling = false
+      seconds_3 = false
+      seconds_2 = false
+      seconds_1 = false
       if Settings.FrameAutoClose then frame:Hide() end
     end
     if times > 0 and item_query < 0 and not check_item(item) then

--- a/LootBlare/ui.lua
+++ b/LootBlare/ui.lua
@@ -563,7 +563,7 @@ end
 function create_settings_frame()
   local frame = CreateFrame('Frame', 'settings_frame', UIParent)
   frame:SetWidth(300)
-  frame:SetHeight(330)
+  frame:SetHeight(360)
   frame:SetPoint('CENTER', UIParent, 'CENTER', 0, 0)
   frame:SetBackdrop({
     bgFile = 'Interface/Tooltips/UI-Tooltip-Background',
@@ -639,7 +639,6 @@ function create_settings_frame()
   frame_duration_edit_box:SetHeight(15)
   frame_duration_edit_box:SetAutoFocus(false)
   frame_duration_edit_box:SetFontObject('ChatFontNormal')
-  frame_duration_edit_box:SetAutoFocus(false)
   frame_duration_edit_box:SetNumeric(true)
   local frame_duration_label = frame:CreateFontString(nil, 'OVERLAY',
                                                       'GameFontNormal')
@@ -664,16 +663,39 @@ function create_settings_frame()
     'Reset PO after importing SRs');
   reset_po_after_importing_sr_cb.tooltip = 'Reset PO after importing SRs'
 
+  -- min quality for items to announce in chat
+  local loot_announce_min_quality_edit_box =
+    CreateFrame('EditBox', 'loot_announce_min_quality_edit_box', frame,
+                'InputBoxTemplate')
+  loot_announce_min_quality_edit_box:SetPoint('TOPLEFT',
+                                              reset_po_after_importing_sr_cb,
+                                              'BOTTOMLEFT', 10, -10)
+  loot_announce_min_quality_edit_box:SetWidth(20)
+  loot_announce_min_quality_edit_box:SetHeight(15)
+  loot_announce_min_quality_edit_box:SetAutoFocus(false)
+  loot_announce_min_quality_edit_box:SetFontObject('ChatFontNormal')
+  loot_announce_min_quality_edit_box:SetNumeric(true)
+  local loot_announce_min_quality_label =
+    frame:CreateFontString(nil, 'OVERLAY', 'GameFontNormal')
+  loot_announce_min_quality_label:SetPoint('LEFT',
+                                           loot_announce_min_quality_edit_box,
+                                           'RIGHT', 5, 0)
+  loot_announce_min_quality_label:SetText('Loot announce min quality (0-4)')
+
   frame:RegisterEvent('OnShow')
   frame:SetScript('OnShow', function()
     if master_looter ~= UnitName('player') then
       prio_main_over_alts_cb:Disable()
       reset_po_after_importing_sr_cb:Disable()
       reset_po_after_importing_sr_cb:Hide()
+      loot_announce_min_quality_edit_box:Hide()
+      loot_announce_min_quality_label:Hide()
     else
       prio_main_over_alts_cb:Enable()
       reset_po_after_importing_sr_cb:Enable()
       reset_po_after_importing_sr_cb:Show()
+      loot_announce_min_quality_edit_box:Show()
+      loot_announce_min_quality_label:Show()
     end
 
     local current_ml = master_looter or 'unknown'
@@ -684,6 +706,8 @@ function create_settings_frame()
     frame_duration_edit_box:SetText(Settings.RollDuration)
     reset_po_after_importing_sr_cb:SetChecked(Settings.ResetPOAfterImportingSR)
     prio_main_over_alts_cb:SetChecked(Settings.PrioMainOverAlts)
+    loot_announce_min_quality_edit_box:SetText(
+      Settings.LootAnnounceMinQuality or 4)
   end)
 
   local save_button = CreateFrame('Button', nil, frame, 'UIPanelButtonTemplate')
@@ -699,6 +723,8 @@ function create_settings_frame()
       Settings.ResetPOAfterImportingSR =
         reset_po_after_importing_sr_cb:GetChecked() == 1
       Settings.PrioMainOverAlts = prio_main_over_alts_cb:GetChecked() == 1
+      Settings.LootAnnounceMinQuality =
+        loot_announce_min_quality_edit_box:GetText()
       send_ml_settings()
     end
 

--- a/LootBlare/utils.lua
+++ b/LootBlare/utils.lua
@@ -150,10 +150,11 @@ function play_sound(path)
   PlaySoundFile(path, 'Master')
 end
 
-function run_if_master_looter(callback)
+function run_if_master_looter(callback, notify)
+  if notify == nil then notify = true end
   if is_master_looter(UnitName('player')) then
     callback()
-  else
+  elseif notify then
     lb_print('You are not the master looter')
   end
 end


### PR DESCRIPTION
List of changes:

- [x] Add auto reset PlusOne function when changing raids. 
- [x] Add announce loot feature when looting something. 
  - This feature can be turned on and off in the settings panel
  - The minimum quality of the items to announce can be changed in the settings panel. 
  - To prevent repetition when looting the same corpse multiple times, this feature uses SuperWoW. If you don't use SuperWoW turning this off is advised 
- [x] Add a countdown timer when the time is ending, and a message is sent when the time has ended